### PR TITLE
Demo for usage of StateMachine

### DIFF
--- a/demo/apps/myapp/mystatemachine.go
+++ b/demo/apps/myapp/mystatemachine.go
@@ -1,0 +1,93 @@
+package myapp
+
+import (
+	"fmt"
+	"time"
+
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+)
+
+// Order with the states: new, processing, shipped, delivered, canceled
+
+type OrderData struct {
+	items     []string
+	processed time.Time
+	shipped   time.Time
+	delivered time.Time
+	canceled  time.Time
+}
+
+type Order struct {
+	act.StateMachine[OrderData]
+}
+
+func factoryOrder() gen.ProcessBehavior {
+	return &Order{}
+}
+
+func (order *Order) Init(args ...any) (act.StateMachineSpec[OrderData], error) {
+	spec := act.NewStateMachineSpec(gen.Atom("new"),
+		// new
+		act.WithStateCallback(gen.Atom("new"), process),
+		act.WithStateCallback(gen.Atom("new"), cancel),
+		// processing
+		act.WithStateCallback(gen.Atom("processing"), ship),
+		act.WithStateCallback(gen.Atom("processing"), cancel),
+		// shipped
+		act.WithStateCallback(gen.Atom("shipped"), deliver),
+	)
+
+	return spec, nil
+}
+
+type Process struct{}
+
+type Ship struct {
+	priority bool
+}
+
+type Deliver struct{}
+
+type Cancel struct {
+	reason string
+}
+
+func process(sm *act.StateMachine[OrderData], message Process) error {
+	data := sm.Data()
+	if len(data.items) < 1 {
+		return fmt.Errorf("can't process order as there are no items added yet")
+	}
+	sm.Log().Info("processing order...")
+	data.processed = time.Now()
+	sm.SetData(data)
+	sm.SetCurrentState(gen.Atom("processing"))
+	return nil
+}
+
+func ship(sm *act.StateMachine[OrderData], message Ship) error {
+	data := sm.Data()
+	sm.Log().Info("shiping order...")
+	data.shipped = time.Now()
+	sm.SetData(data)
+	sm.SetCurrentState(gen.Atom("shipped"))
+	return nil
+}
+
+func deliver(sm *act.StateMachine[OrderData], message Deliver) error {
+	data := sm.Data()
+	sm.Log().Info("delivering order...")
+	data.delivered = time.Now()
+	sm.SetData(data)
+	sm.SetCurrentState(gen.Atom("delivered"))
+	return nil
+}
+
+func cancel(sm *act.StateMachine[OrderData], message Cancel) error {
+	data := sm.Data()
+	sm.Log().Info("canceling order...")
+	data.canceled = time.Now()
+	sm.SetData(data)
+	sm.SetCurrentState(gen.Atom("canceled"))
+	return nil
+}

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -3,16 +3,17 @@ module demo
 go 1.21.6
 
 require (
-	ergo.services/application v0.0.0-20240904055159-7f2e1a954c05
-	ergo.services/ergo v1.999.300
-	ergo.services/logger v0.0.0-20240904054830-18407beea628
-)
+        ergo.services/application v0.0.0-20240904055159-7f2e1a954c05
+        ergo.services/ergo v1.999.300
+        ergo.services/logger v0.0.0-20240904054830-18407beea628
+        )
 
 require (
-	ergo.services/meta v0.0.0-20240904054930-a97f6add8a78 // indirect
-	github.com/fatih/color v1.16.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-)
+        ergo.services/meta v0.0.0-20240904054930-a97f6add8a78 // indirect
+        github.com/fatih/color v1.16.0 // indirect
+        github.com/gorilla/websocket v1.5.0 // indirect
+        github.com/mattn/go-colorable v0.1.13 // indirect
+        github.com/mattn/go-isatty v0.0.20 // indirect
+        golang.org/x/sys v0.14.0 // indirect
+        )
+


### PR DESCRIPTION
Example for the usage of `act.StateMachine`. This example is inspired by the code lock example from the `gen_statem` [documentation](https://www.erlang.org/doc/system/statem.html#example-revisited).

We model a code lock as a state machine. This example demonstrates the following features:
- `StateMessageHandler` allows you do register a message for a specific state. Here for example we register the `handleButtonPress` handler that receives the `ButtonPress` message in the `open` state.
- `StateCallHandler` similar to `StateMessageHandler` but represents a synchronous call with a return value. In this example we register a `StateCallHandler` to query the length of the code.
- `StateEnterCallback` allows for a callback that is triggered on every state transition. This is useful for orthogonal concerns like logging, auditing etc.
- `StateTimeout` provides a timer that sends a message to the state machine on timeout. If the state machine transitions to another state before the timeout, the timer is canceled. In this example we set a state timeout for the `open` state. After 10 seconds in this state the state machine automatically moves to the `locked` state.
- `MessageTimeout` is useful for measuring inactivity. We set up a message timeout after pressing each button. After 30 seconds of inactivity the buttons are cleared. A `MessageTimeout` timer is canceled by any type of message or event.

![ergo-codelock-example](https://github.com/user-attachments/assets/8e0b7c11-160d-4379-a0b9-43065611992d)

See https://github.com/ergo-services/ergo/pull/218